### PR TITLE
fixed a bug related to rlnClassNumber matching

### DIFF
--- a/STAR.py
+++ b/STAR.py
@@ -209,7 +209,7 @@ class STAR():
 
     #Speficialized function for STAR Modification
     def human_recenter(self, minx, miny, maxx, maxy, d, inplace = True):
-        df = self._content[self._content.rlnClassNumber.isin(d.keys())]
+        df = self._content[self._content.rlnClassNumber.isin([int(key) for key in d.keys()])]
         if self.get_star_version() == "3.0":
             downscale_factor = int(input("Please provide the downscale factor of parcticle stacks:\n"))
             for idx, row in df.iterrows():


### PR DESCRIPTION
`rlnClassNumber` in contents is an int, but `d.keys()` are strings. This change converts the `d.keys()` into ints for proper comparisons.